### PR TITLE
Revert "Rolling xunit back to 2.1.0 to try to fix dotcover issue."

### DIFF
--- a/test/RollbarDotNet.Tests/project.json
+++ b/test/RollbarDotNet.Tests/project.json
@@ -3,11 +3,11 @@
   "dependencies": {
     "RollbarDotNet": "0.3.0-*",
     "Moq": "4.6.25-alpha",
-    "dotnet-test-xunit": "1.0.0-rc2-build10025",
+    "dotnet-test-xunit": "2.2.0-preview2-build1029",
     "Microsoft.NETCore.App": "1.0.0",
     "NETStandard.Library": "1.6.0",
     "System.Diagnostics.TraceSource": "4.0.0",
-    "xunit": "2.1.0"
+    "xunit": "2.2.0-beta2-build3300"
   },
   "testRunner": "xunit",
   "frameworks": {


### PR DESCRIPTION
Reverts RoushTech/RollbarDotNet#26
