### PR TITLE
Moves over to using IOptions<> instead of IConfigurationRoot,

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,42 @@
-﻿# v0.3.0
+﻿# 0.5.0
+<sup>Released: TBD</sup>
+
+## Features
+
+- IHttpContextAccessor is no longer assumed to be included as part of `AddIdentity()`, we'll add it.
+- Testing of dependency injection for web platforms (console apps coming soon).
+- Switching to the use of `IOptions<RollbarOptions>` instead of `IConfigurationRoot`.
+
+# 0.4.0
+<sup>Released: 2016/9/30</sup>
+
+## Features
+
+- Upgrade for .NET Core 1.0 release.
+
+# 0.3.0
 <sup>Released: 2016/6/12</sup>
+
+## Features
 
 - Added support for cookies on request body.
 - Added blacklisting variables by name.
 
-# v0.2.0
+# 0.2.0
 <sup>Released: 2016/6/9</sup>
+
+## Features
 
 - Rollbar message UUID available after error is reported.
 - Removed custom parameters from message body.
 - Documentation for required configuration variables 
 
 
-# v0.1.0
+# 0.1.0
 <sup>Released: 2016/5/31</sup>
 
 Initial release.
+
+## Features
 
 - Ability to send basic logs to Rollbar

--- a/RollbarDotNet.sln
+++ b/RollbarDotNet.sln
@@ -1,12 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{FBE55ED6-5E60-41F8-B5C0-7C97D04A1A6C}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{04899B07-3768-4373-9CB8-1A0DBA28C035}"
 	ProjectSection(SolutionItems) = preProject
+		CHANGELOG.md = CHANGELOG.md
 		global.json = global.json
 		LICENSE.txt = LICENSE.txt
 		Readme.md = Readme.md

--- a/src/RollbarDotNet/Blacklisters/ConfigurationBlacklister.cs
+++ b/src/RollbarDotNet/Blacklisters/ConfigurationBlacklister.cs
@@ -8,9 +8,9 @@
 
     public class ConfigurationBlacklister : IBlacklister
     {
-        public ConfigurationBlacklister(IOptions<BlacklistConfiguration> config)
+        public ConfigurationBlacklister(IOptions<RollbarOptions> config)
         {
-            this.Configuration = config?.Value;
+            this.Configuration = config?.Value?.Blacklist;
             this.RegexChecks = new List<Regex>();
             this.StringChecks = new List<string>();
             if (this.Configuration != null)

--- a/src/RollbarDotNet/Builder/ConfigurationBuilder.cs
+++ b/src/RollbarDotNet/Builder/ConfigurationBuilder.cs
@@ -1,31 +1,32 @@
 ﻿namespace RollbarDotNet.Builder
 {
-    using Microsoft.Extensions.Configuration;
+    using Configuration;
+    using Microsoft.Extensions.Options;
     using Payloads;
     using System;
 
     public class ConfigurationBuilder : IBuilder
     {
-        public ConfigurationBuilder(IConfigurationRoot configuration)
+        public ConfigurationBuilder(IOptions<RollbarOptions> configuration)
         {
-            this.Configuration = configuration;
+            this.Configuration = configuration.Value;
         }
 
-        protected IConfigurationRoot Configuration { get; set; }
+        protected RollbarOptions Configuration { get; set; }
 
         public void Execute(Payload payload)
         {
-            payload.AccessToken = this.Configuration["Rollbar:AccessToken"];
-            payload.Data.Environment = this.Configuration["Rollbar:Environment"];
+            payload.AccessToken = this.Configuration.AccessToken;
+            payload.Data.Environment = this.Configuration.Environment;
 
             if(string.IsNullOrEmpty(payload.AccessToken))
             {
-                throw new InvalidOperationException("Configuration variable Rollbar:AccessToken must be set.");
+                throw new InvalidOperationException("Configuration variable for your Rollbar AccessToken must be set (did you include services.Configure<RollbarOptions>?).");
             }
 
             if (string.IsNullOrEmpty(payload.Data.Environment))
             {
-                throw new InvalidOperationException("Configuration variable Rollbar:Environment must be set.");
+                throw new InvalidOperationException("Configuration variable for your Rollbar Environment must be set (did you include services.Configure<RollbarOptions>?).");
             }
         }
     }

--- a/src/RollbarDotNet/Builder/RequestBuilder.cs
+++ b/src/RollbarDotNet/Builder/RequestBuilder.cs
@@ -29,6 +29,11 @@
         protected void BuildRequest(Request request)
         {
             var context = this.contextAccessor.HttpContext;
+            if(context == null)
+            {
+                return;
+            }
+
             request.Url = $"{context.Request.Scheme}://{context.Request.Host}{context.Request.Path}";
             request.Method = context.Request.Method.ToUpper();
             request.Headers = this.HeadersToDictionary(context.Request.Headers);

--- a/src/RollbarDotNet/Configuration/RollbarOptions.cs
+++ b/src/RollbarDotNet/Configuration/RollbarOptions.cs
@@ -1,0 +1,11 @@
+﻿namespace RollbarDotNet.Configuration
+{
+    public class RollbarOptions
+    {
+        public string AccessToken { get; set; }
+
+        public string Environment { get; set; }
+
+        public BlacklistConfiguration Blacklist { get; set; }
+    }
+}

--- a/src/RollbarDotNet/Core/ServiceExtensions.cs
+++ b/src/RollbarDotNet/Core/ServiceExtensions.cs
@@ -4,12 +4,15 @@
     using Blacklisters;
     using Builder;
     using Configuration;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.DependencyInjection.Extensions;
+    using Microsoft.Extensions.Options;
 
     public static class ServiceExtensions
     {
-        public static IServiceCollection AddRollbar(this IServiceCollection services, IConfigurationRoot configuration)
+        public static IServiceCollection AddRollbar(this IServiceCollection services)
         {
             return services
                 .AddSingleton<IBuilder, Builder.ConfigurationBuilder>()
@@ -19,15 +22,16 @@
                 .AddSingleton<IEnvironment, SystemEnvironment>()
                 .AddSingleton<IBlacklister, ConfigurationBlacklister>()
                 .AddSingleton<IBlacklistCollection, BlacklistCollection>()
-                .Configure<BlacklistConfiguration>(configuration.GetSection("Rollbar:Blacklist"))
                 .AddScoped<Rollbar>();
         }
 
-        public static IServiceCollection AddRollbarWeb(this IServiceCollection services, IConfigurationRoot configuration)
+        public static IServiceCollection AddRollbarWeb(this IServiceCollection services)
         {
-            return AddRollbar(services, configuration)
+            services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+            return services.AddRollbar()
                 .AddSingleton<IBuilder, ServerBuilder>()
                 .AddScoped<IBuilder, RequestBuilder>();
+
         }
     }
 }

--- a/src/RollbarDotNet/RollbarClient.cs
+++ b/src/RollbarDotNet/RollbarClient.cs
@@ -6,6 +6,7 @@
     using System.Net.Http;
     using System.Net.Http.Headers;
     using Payloads;
+
     public class RollbarClient
     {
         public RollbarClient()
@@ -28,7 +29,7 @@
                 var response = await httpClient.PostAsync(this.RollbarUri, new JsonHttpContentSerializer(json));
                 if (!response.IsSuccessStatusCode)
                 {
-                    throw new System.Exception(response.ToString());
+                    throw new HttpRequestException(response.ToString());
                 }
                 else
                 {

--- a/src/RollbarDotNet/project.json
+++ b/src/RollbarDotNet/project.json
@@ -18,6 +18,7 @@
   "version": "0.5.0",
   "dependencies": {
     "Microsoft.AspNetCore.Hosting.Abstractions": "1.0.0",
+    "Microsoft.AspNetCore.Http": "1.0.0",
     "Microsoft.Extensions.Configuration.Abstractions": "1.0.0",
     "Microsoft.Extensions.DependencyInjection": "1.0.0",
     "Microsoft.Extensions.Options": "1.0.0",

--- a/test/RollbarDotNet.Tests/Blacklisters/ConfigurationBlacklisterTests.cs
+++ b/test/RollbarDotNet.Tests/Blacklisters/ConfigurationBlacklisterTests.cs
@@ -39,18 +39,15 @@
 
         protected ConfigurationBlacklister Setup()
         {
-            var configurationBlacklistMock = new Mock<IOptions<BlacklistConfiguration>>();
-            var blacklistConfigurationMock = new Mock<BlacklistConfiguration>();
-            blacklistConfigurationMock.Setup(c => c.Text).Returns(new List<string>()
+            var configurationBlacklistMock = new Mock<IOptions<RollbarOptions>>();
+            configurationBlacklistMock.Setup(c => c.Value).Returns(new RollbarOptions
             {
-                "test",
+                Blacklist = new BlacklistConfiguration
+                {
+                    Regex = new List<string> { "^rege.$" },
+                    Text = new List<string> { "test" }
+                }
             });
-            blacklistConfigurationMock.Setup(c => c.Regex).Returns(new List<string>()
-            {
-                "^rege.$"
-            });
-
-            configurationBlacklistMock.Setup(c => c.Value).Returns(blacklistConfigurationMock.Object);
             return new ConfigurationBlacklister(configurationBlacklistMock.Object);
         }
     }

--- a/test/RollbarDotNet.Tests/Builder/ConfigurationBuilderTests.cs
+++ b/test/RollbarDotNet.Tests/Builder/ConfigurationBuilderTests.cs
@@ -1,6 +1,8 @@
 ﻿namespace RollbarDotNet.Tests.Builder
 {
+    using Configuration;
     using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.Options;
     using Moq;
     using RollbarDotNet.Builder;
     using System;
@@ -14,28 +16,28 @@
         [Fact]
         public void Require_Access_Token()
         {
-            var configurationMock = new Mock<IConfigurationRoot>();
+            var configurationMock = new Mock<IOptions<RollbarOptions>>();
+            configurationMock.Setup(c => c.Value).Returns(new RollbarOptions());
             var configurationBuilder = new RollbarDotNet.Builder.ConfigurationBuilder(configurationMock.Object);
             var exception = Assert.Throws<InvalidOperationException>(() => configurationBuilder.Execute(new Payloads.Payload()));
-            Assert.Equal("Configuration variable Rollbar:AccessToken must be set.", exception.Message);
+            Assert.Equal("Configuration variable for your Rollbar AccessToken must be set (did you include services.Configure<RollbarOptions>?).", exception.Message);
         }
 
         [Fact]
         public void Require_Environment()
         {
-            var configurationMock = new Mock<IConfigurationRoot>();
-            configurationMock.Setup(c => c["Rollbar:AccessToken"]).Returns(ACCESSTOKEN);
+            var configurationMock = new Mock<IOptions<RollbarOptions>>();
+            configurationMock.Setup(c => c.Value).Returns(new RollbarOptions { AccessToken = ACCESSTOKEN });
             var configurationBuilder = new RollbarDotNet.Builder.ConfigurationBuilder(configurationMock.Object);
             var exception = Assert.Throws<InvalidOperationException>(() => configurationBuilder.Execute(new Payloads.Payload()));
-            Assert.Equal("Configuration variable Rollbar:Environment must be set.", exception.Message);
+            Assert.Equal("Configuration variable for your Rollbar Environment must be set (did you include services.Configure<RollbarOptions>?).", exception.Message);
         }
         
         [Fact]
         public void SetsPayload()
         {
-            var configurationMock = new Mock<IConfigurationRoot>();
-            configurationMock.Setup(c => c["Rollbar:AccessToken"]).Returns(ACCESSTOKEN);
-            configurationMock.Setup(c => c["Rollbar:Environment"]).Returns(ENVIRONMENT);
+            var configurationMock = new Mock<IOptions<RollbarOptions>>();
+            configurationMock.Setup(c => c.Value).Returns(new RollbarOptions { AccessToken = ACCESSTOKEN, Environment = ENVIRONMENT });
             var configurationBuilder = new RollbarDotNet.Builder.ConfigurationBuilder(configurationMock.Object);
             var payload = new Payloads.Payload();
             configurationBuilder.Execute(payload);

--- a/test/RollbarDotNet.Tests/Builder/RequestBuilderTests.cs
+++ b/test/RollbarDotNet.Tests/Builder/RequestBuilderTests.cs
@@ -113,7 +113,7 @@
             Assert.Equal("?query=test&blacklist=**********", queryString);
         }
 
-        protected Payload GeneratePayload(bool enableBlacklist = false, string method = "GET")
+        public IHttpContextAccessor CreateIHttpContextAccessor(string method)
         {
             var httpContextAccessorMock = new Mock<IHttpContextAccessor>();
             httpContextAccessorMock.Setup(h => h.HttpContext.Request.Scheme).Returns("http");
@@ -126,12 +126,17 @@
             httpContextAccessorMock.Setup(h => h.HttpContext.Request.Form).Returns(this.GenerateFormCollection);
             httpContextAccessorMock.Setup(h => h.HttpContext.Request.Cookies).Returns(this.GenerateCookieCollection);
             httpContextAccessorMock.Setup(h => h.HttpContext.Request.QueryString).Returns(new QueryString("?query=test&blacklist=here"));
+            return httpContextAccessorMock.Object;
+        }
+
+        protected Payload GeneratePayload(bool enableBlacklist = false, string method = "GET")
+        {
 
             var blacklistCollectionMock = new Mock<IBlacklistCollection>();
             blacklistCollectionMock.Setup(b => b.Check("test")).Returns(false);
             blacklistCollectionMock.Setup(b => b.Check("blacklist")).Returns(enableBlacklist);
 
-            var requestBuilder = new RequestBuilder(blacklistCollectionMock.Object, httpContextAccessorMock.Object);
+            var requestBuilder = new RequestBuilder(blacklistCollectionMock.Object, this.CreateIHttpContextAccessor(method));
             var payload = new Payload();
             requestBuilder.Execute(payload);
             return payload;

--- a/test/RollbarDotNet.Tests/DependencyInjection/WebDependencyInjectionTests.cs
+++ b/test/RollbarDotNet.Tests/DependencyInjection/WebDependencyInjectionTests.cs
@@ -1,0 +1,54 @@
+﻿namespace RollbarDotNet.Tests.DependencyInjection
+{
+    using Configuration;
+    using Core;
+    using Microsoft.AspNetCore.Hosting;
+    using Microsoft.Extensions.DependencyInjection;
+    using Moq;
+    using System;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Xunit;
+
+    public class WebDependencyInjectionTests
+    {
+        public WebDependencyInjectionTests()
+        {
+            var mockHostingEnvironment = new Mock<IHostingEnvironment>();
+            var services = new ServiceCollection();
+            services.AddOptions()
+                    .AddRollbarWeb()
+                    .AddSingleton(mockHostingEnvironment.Object);
+
+            services.Configure<RollbarOptions>(o =>
+            {
+                o.AccessToken = "test";
+                o.Environment = "Testing";
+            });
+
+            this.Services = services;
+            this.ServiceProvider = this.Services.BuildServiceProvider();
+            this.Rollbar = this.ServiceProvider.GetService<Rollbar>();
+        }
+
+        protected IServiceCollection Services { get; set; }
+
+        protected IServiceProvider ServiceProvider { get; set; }
+
+        protected Rollbar Rollbar { get; set; }
+
+        [Fact]
+        public async Task SucessfullyReportError()
+        {
+            try
+            {
+                throw new Exception("Test");
+            }
+            catch(Exception exception)
+            {
+                // We're expecting a 401 due to the bad access token, anything else means we failed to DI.
+                await Assert.ThrowsAsync<HttpRequestException>(async () => await this.Rollbar.SendException(exception));
+            }
+        }
+    }
+}


### PR DESCRIPTION
automatically configures IHttpContextAccessor if not already registered
new tests for testing DI, instructions on how to use without DI.