### PR TITLE
Fixed a hole in testing, fixed a bug where you can't send exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
-﻿# 0.5.0
-<sup>Released: TBD</sup>
+﻿# 0.5.1
+<sup>Released: 2017/3/10</sup>
+
+## Features
+
+ - More robust testing of sending exceptions to Rollbar (see readme.md for instructions on configuring token for testing).
+
+## Bug Fixes
+
+ - Fixed issue sending Rollbar exceptions.
+
+# 0.5.0
+<sup>Released: 2017/2/26</sup>
 
 ## Features
 

--- a/Readme.md
+++ b/Readme.md
@@ -4,6 +4,12 @@ Rollbar support for your .NET Core projects, relies on dependency injection and 
 
 Inspired by RollbarSharp, great library, just required too many tweaks to make play with .NET core well in my opinion.
 
+# Testing
+
+Environment variables for testing:
+
+ * ROLLBAR_TOKEN - Rollbar token for testing.
+
 # Required services
 
 Please make sure the following services are available for the various builder modules.

--- a/src/RollbarDotNet/Payloads/Body.cs
+++ b/src/RollbarDotNet/Payloads/Body.cs
@@ -8,7 +8,6 @@
     {
         public Body()
         {
-            this.Message = new Message();
         }
 
         [JsonProperty("trace")]

--- a/src/RollbarDotNet/Rollbar.cs
+++ b/src/RollbarDotNet/Rollbar.cs
@@ -46,6 +46,7 @@
         public async Task<Response> SendMessage(RollbarLevel level, string message)
         {
             var payload = this.SetupPayload(level);
+            payload.Data.Body.Message = new Message();
             payload.Data.Body.Message.Body = message;
             return await this.RollbarClient.Send(payload);
         }

--- a/src/RollbarDotNet/project.json
+++ b/src/RollbarDotNet/project.json
@@ -15,7 +15,7 @@
       "Error"
     ]
   },
-  "version": "0.5.0",
+  "version": "0.5.1",
   "dependencies": {
     "Microsoft.AspNetCore.Hosting.Abstractions": "1.0.0",
     "Microsoft.AspNetCore.Http": "1.0.0",

--- a/test/RollbarDotNet.Tests/DependencyInjection/WebDependencyInjectionTests.cs
+++ b/test/RollbarDotNet.Tests/DependencyInjection/WebDependencyInjectionTests.cs
@@ -6,7 +6,6 @@
     using Microsoft.Extensions.DependencyInjection;
     using Moq;
     using System;
-    using System.Net.Http;
     using System.Threading.Tasks;
     using Xunit;
 
@@ -19,10 +18,9 @@
             services.AddOptions()
                     .AddRollbarWeb()
                     .AddSingleton(mockHostingEnvironment.Object);
-
             services.Configure<RollbarOptions>(o =>
             {
-                o.AccessToken = "test";
+                o.AccessToken = Environment.GetEnvironmentVariable("ROLLBAR_TOKEN");
                 o.Environment = "Testing";
             });
 
@@ -46,21 +44,20 @@
             }
             catch(Exception exception)
             {
-                // We're expecting a 401 due to the bad access token, anything else means we failed to DI.
-                await Assert.ThrowsAsync<HttpRequestException>(async () => await this.Rollbar.SendException(exception));
+                await this.Rollbar.SendException(exception);
             }
         }
 
         [Fact]
         public async Task SuccessfullyReportMessage()
         {
-            await Assert.ThrowsAsync<HttpRequestException>(async () => await this.Rollbar.SendMessage("Hello"));
+            await this.Rollbar.SendMessage("Hello");
         }
 
         [Fact]
         public async Task SuccessfullyReportMessageWithLevel()
         {
-            await Assert.ThrowsAsync<HttpRequestException>(async () => await this.Rollbar.SendMessage(RollbarLevel.Debug, "Hello"));
+            await this.Rollbar.SendMessage(RollbarLevel.Debug, "Hello");
         }
     }
 }


### PR DESCRIPTION
**due** to new message object being defined in 0.5.0.