### PR TITLE
for ExceptionHandlerMiddleware, move Rollbar to a per-request depende…

### DIFF
--- a/src/RollbarDotNet/Core/ExceptionHandlerMiddleware.cs
+++ b/src/RollbarDotNet/Core/ExceptionHandlerMiddleware.cs
@@ -7,18 +7,14 @@
     public class ExceptionHandlerMiddleware
     {
         public ExceptionHandlerMiddleware(
-            RequestDelegate next,
-            Rollbar rollbar)
+            RequestDelegate next)
         {
             this.Next = next;
-            this.Rollbar = rollbar;
         }
 
         protected RequestDelegate Next { get; set; }
-        
-        protected Rollbar Rollbar { get; set; }
 
-        public async Task Invoke(HttpContext context)
+        public async Task Invoke(HttpContext context, Rollbar rollbar)
         {
             try
             {
@@ -26,7 +22,7 @@
             }
             catch(Exception exception)
             {
-                var response = await this.Rollbar.SendException(exception);
+                var response = await rollbar.SendException(exception);
                 var rollbarResponseFeature = new RollbarResponseFeature
                 {
                     Handled = true,


### PR DESCRIPTION
…ncy to avoid the error:
```
Cannot resolve scoped service 'RollbarDotNet.Rollbar' from root provider.
```
I was getting the following error in ASP.NET Core 2.0 and followed the[ middleware docs ](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/middleware) to change `Rollbar` to a per-request dependency since it needs other per-request stuff like `RequestBuilder`

```
An error occurred while starting the application.

InvalidOperationException: Cannot resolve scoped service 'RollbarDotNet.Rollbar' from root provider.
Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteValidator.ValidateResolution(Type serviceType, ServiceProvider serviceProvider)

InvalidOperationException: Cannot resolve scoped service 'RollbarDotNet.Rollbar' from root provider.
Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteValidator.ValidateResolution(Type serviceType, ServiceProvider serviceProvider)
Microsoft.Extensions.DependencyInjection.ServiceProvider.GetService(Type serviceType)
Microsoft.Extensions.Internal.ActivatorUtilities+ConstructorMatcher.CreateInstance(IServiceProvider provider)
Microsoft.Extensions.Internal.ActivatorUtilities.CreateInstance(IServiceProvider provider, Type instanceType, Object[] parameters)
Microsoft.AspNetCore.Builder.UseMiddlewareExtensions+<>c__DisplayClass4_0.<UseMiddleware>b__0(RequestDelegate next)
Microsoft.AspNetCore.Builder.Internal.ApplicationBuilder.Build()
Microsoft.AspNetCore.Hosting.Internal.WebHost.BuildApplication()
```