### PR TITLE
fix error when method doesn't have a declaring type

### DIFF
--- a/src/RollbarDotNet/Builder/ExceptionBuilder.cs
+++ b/src/RollbarDotNet/Builder/ExceptionBuilder.cs
@@ -54,7 +54,7 @@
                     : method.GetParameters()
                         .Select(p => $"{p.ParameterType.FullName} {p.Name}")
                         .Aggregate((p1, p2) => $"{p1}, {p2}");
-                var methodName = $"{method.DeclaringType.FullName}.{method.Name}({parameters})";
+                var methodName = $"{method.DeclaringType?.FullName ?? "(unknown)"}.{method.Name}({parameters})";
                 var frame = new Frame
                 {
                     Filename = stackTraceFrame.GetFileName(),

--- a/src/RollbarDotNet/Builder/ExceptionBuilder.cs
+++ b/src/RollbarDotNet/Builder/ExceptionBuilder.cs
@@ -45,7 +45,12 @@
         {
             var frames = new List<Frame>();
             var stacktrace = new StackTrace(exception, true);
-            foreach (var stackTraceFrame in stacktrace.GetFrames())
+            var stackTraceFrames = stacktrace.GetFrames();
+            if (stackTraceFrames == null)
+            {
+                return frames;
+            }
+            foreach (var stackTraceFrame in stackTraceFrames)
             {
                 var method = stackTraceFrame.GetMethod();
                 var methodParameters = method.GetParameters();


### PR DESCRIPTION
The declaring type is sometimes null. Here's how RollbarSharp handled it:

https://github.com/mroach/RollbarSharp/blob/master/src/RollbarSharp/Builders/FrameModelBuilder.cs#L56

```
fileName = method.ReflectedType != null
			   ? method.ReflectedType.FullName
			   : "(unknown)";
```
